### PR TITLE
Add photo and conference details to API /speakers/:id

### DIFF
--- a/api/views/speakers/show.json.jbuilder
+++ b/api/views/speakers/show.json.jbuilder
@@ -2,6 +2,12 @@ json.(speaker, :id, :name, :twitter)
 json.talks speaker.talks do |talk|
   json.(talk, :id, :title, :description, :video_url, :conference_id, :slug)
 
+  json.conference do
+    json.(talk.conference, :id, :title, :description, :start_date, :end_date,
+      :image_url, :place, :place_url, :tags, :twitter, :year, :slug)
+    json.website talk.conference.url
+  end
+
   json.speakers talk.speakers do |speaker|
     json.(speaker, :id, :name, :twitter)
   end


### PR DESCRIPTION
Add to API `/api/speakers/:id`
- Details about the conferences
- Photo of the speaker *

`* Note *`
The url given could result in a 404.
Default avatar is `http://confy-assets.wecode.io/speakers/generic-speaker.png`
