### PR TITLE
Error when an invalid vimeo url is provided to talks_helper fixed.

### DIFF
--- a/app/helpers/talks_helper.rb
+++ b/app/helpers/talks_helper.rb
@@ -1,8 +1,7 @@
 require 'net/http'
 require 'json'
 
-Confy::App.helpers do
-
+module TalksHelper
   def video_iframe(video_url)
     if video_url.include? 'vimeo' then
       "//player.vimeo.com/video/#{video_url.split('/').last}"
@@ -13,10 +12,15 @@ Confy::App.helpers do
 
   def video_thumbnail(video_url)
     if video_url.include? 'vimeo' then
-      result = Net::HTTP.get(URI.parse("http://vimeo.com/api/v2/video/#{video_url.split('/').last}.json"))
-      JSON.parse(result)[0]["thumbnail_large"]
+      result = Net::HTTP.get_response(URI.parse("http://vimeo.com/api/v2/video/#{video_url.split('/').last}.json"))
+      if result.code == '404'
+        return 'https://via.placeholder.com/640x480/18213d/ffffff?text=VIDEO IS NOT READY YET. SORRY!'
+      end
+      JSON.parse(result.body)[0]["thumbnail_large"]
     else
       "//img.youtube.com/vi/#{video_url.split('=').last}/maxresdefault.jpg"
     end
   end
 end
+
+Confy::App.helpers TalksHelper

--- a/spec/helpers/talks_helper_spec.rb
+++ b/spec/helpers/talks_helper_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../spec_helper'
+require 'rack/test'
+require File.expand_path('app/app')
+require File.expand_path('app/helpers/talks_helper')
+
+describe 'TalksHelper' do
+  include Rack::Test::Methods
+
+  subject do
+    Class.new { include TalksHelper }
+  end
+
+  def app
+    Confy::App
+  end
+
+  it 'should return not found default image if video does not exists' do
+    wrong_video_url = 'https://vimeo.com/63628137'
+    @result = subject.new.video_thumbnail(wrong_video_url)
+    @result == 'https://via.placeholder.com/640x480/18213d/ffffff?text=VIDEO IS NOT READY YET. SORRY!'
+  end
+
+end


### PR DESCRIPTION
## Scenario
> When an invalid vimeo video url is provided an error is throwed.

## Solution

When a `video_url` is provided, a placehold.it url with a `VIDEO IS NOT READY YET. SORRY!` legend should be returned.

## Additional Notes

I tried to not modify the actual behavior in order to avoid a possible breaking change.

Test were added too in order to recreate this error, and it's fix.